### PR TITLE
feat: set datapath id into ovsdb

### DIFF
--- a/ofctrl/ofctrl.go
+++ b/ofctrl/ofctrl.go
@@ -354,6 +354,15 @@ func (m datapathIDMutateAPP) PacketRcvd(*OFSwitch, *PacketIn)                   
 func (m datapathIDMutateAPP) MultipartReply(*OFSwitch, *openflow13.MultipartReply) {}
 
 func setDatapathID(conn *ovsdb.OvsdbClient, bridgeName string, datapathID []byte) error {
+	if conn == nil {
+		var err error
+		conn, err = ovsdb.ConnectUnix(ovsdb.DEFAULT_SOCK)
+		if err != nil {
+			return fmt.Errorf("connect to ovsdb: %s", err)
+		}
+		defer conn.Disconnect()
+	}
+
 	if hex.EncodedLen(len(datapathID)) != 16 {
 		return fmt.Errorf("invalid datapath id: %s", hex.EncodeToString(datapathID))
 	}


### PR DESCRIPTION
1. datapath-id 在 bridge 创建时会自动生成一个，但是不会持久化；
2. 通过库连接 socket 成功时会有 SwitchConnected 的 callback；
3. 在 callback 中可以获取到 datapath-id，并写入到 ovsdb 的 bridge other_config 中；
