### PR TITLE
fix(ofctrl): Uncertainty in Signal Transmission due to Multiple Parties

### DIFF
--- a/ofctrl/ofctrl.go
+++ b/ofctrl/ofctrl.go
@@ -266,11 +266,6 @@ func (c *Controller) handleConnection(conn net.Conn) {
 				log.Warnf("Received ofp1.3 error msg: %+v", *m)
 				stream.Shutdown <- true
 			}
-		case err := <-stream.Error:
-			disconnected = true
-			// The connection has been shutdown.
-			log.Infof("message stream error %v", err)
-			return
 		case <-time.After(time.Second * 3):
 			// This shouldn't happen. If it does, both the controller
 			// and switch are no longer communicating. The TCPConn is


### PR DESCRIPTION
Reading the Channel

In both the ofctrl and ofSwtich instances, they read from the stream.Error channel, which has a capacity of only 1. When the ovs-vswitchd connection breaks, the system will only write an error signal to this channel once. As a result, only one of the two parties can receive this error signal, and which one will be random. In the previous design, when ofctrl received the error signal, it would only send a signal to the disconnection channel shared with ofswitch. We have improved this by having only ofswtitch receive the error signal, after which ofswitch sends a disconnect signal to ofctrl. This resolves the issue of potentially missing the signal in ofswitch.