### PR TITLE
fix: immediately shutdown on error stream

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,18 +11,15 @@ on:
 
 jobs:
   pr-check:
-    runs-on: [self-hosted, pod]
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: ^1.15
-      - uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: setup docker-compose
+        run: |
+          sudo mkdir -p /usr/libexec/docker/cli-plugins
+          sudo curl -fLo /usr/libexec/docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64
+          sudo chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+          sudo ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
       - run: make docker-build
       - run: make docker-test

--- a/ofctrl/ofctrl.go
+++ b/ofctrl/ofctrl.go
@@ -291,6 +291,11 @@ func (c *Controller) handleConnection(conn net.Conn) {
 				log.Warnf("Received ofp1.3 error msg: %+v", *m)
 				stream.Shutdown <- true
 			}
+		case err := <-stream.Error:
+			disconnected = true
+			// The connection has been shutdown.
+			log.Infof("message stream error %v", err)
+			return
 		case <-time.After(time.Second * 3):
 			// This shouldn't happen. If it does, both the controller
 			// and switch are no longer communicating. The TCPConn is


### PR DESCRIPTION
revert #74 

immediately reconnect when error before connection is established:
```
INFO[0000] /run/openvswitch/zwtop-t01.mgmt is disconnected, connecting...
INFO[0000] Connecting to socket file /run/openvswitch/zwtop-t01.mgmt
INFO[0000] New connection..
WARN[0000] InboundError read unix @->/var/run/openvswitch/zwtop-t01.mgmt: read: connection reset by peer
INFO[0000] Closing OpenFlow message stream.
INFO[0000] message stream error read unix @->/var/run/openvswitch/zwtop-t01.mgmt: read: connection reset by peer
INFO[0000] /run/openvswitch/zwtop-t01.mgmt is disconnected, connecting...
INFO[0000] Connecting to socket file /run/openvswitch/zwtop-t01.mgmt
INFO[0000] New connection..
INFO[0000] Received Openflow 1.3 Hello message
INFO[0000] Received ofp1.3 Switch feature response: {Header:{Version:4 Type:6 Length:32 Xid:4} DPID:00:00:32:af:10:52:2b:4c Buffers:0 NumTables:254 AuxilaryId:0 pad:[0 0] Capabilities:79 Actions:0 Ports:[]}
INFO[0000] Openflow Connection for new switch: 00:00:32:af:10:52:2b:4c
```

fix [everoute/ip-detection#15](https://newgh.smartx.com/everoute/ip-detection/issues/15)