### PR TITLE
feat: clean ofswitch and stream when closed manually

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,9 @@ on:
 
 jobs:
   pr-check:
-    runs-on: ubuntu-20.04
+    runs-on: [ self-hosted, pod ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: setup docker-compose
-        run: |
-          sudo mkdir -p /usr/libexec/docker/cli-plugins
-          sudo curl -fLo /usr/libexec/docker/cli-plugins/docker-compose https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64
-          sudo chmod +x /usr/libexec/docker/cli-plugins/docker-compose
-          sudo ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
       - run: make docker-build
       - run: make docker-test

--- a/deploy/docker-compose/docker-compose.ovs.yaml
+++ b/deploy/docker-compose/docker-compose.ovs.yaml
@@ -4,6 +4,7 @@ services:
   ovsdb-server:
     image: ghcr.io/smartxworks/ovs:2.14.0
     command: ovsdb-server
+    privileged: true
     network_mode: "host"
 
   ovs-vswitchd:

--- a/ofctrl/ofSwitch.go
+++ b/ofctrl/ofSwitch.go
@@ -64,7 +64,7 @@ func init() {
 
 // Builds and populates a Switch struct then starts listening
 // for OpenFlow messages on conn.
-func NewSwitch(stream *util.MessageStream, dpid net.HardwareAddr, app AppInterface, connCh chan int, id uint16, disableCleanGroup bool) *OFSwitch {
+func NewSwitch(pctx context.Context, stream *util.MessageStream, dpid net.HardwareAddr, app AppInterface, connCh chan int, id uint16, disableCleanGroup bool) *OFSwitch {
 	s := getSwitch(dpid)
 	if s == nil {
 		log.Infoln("Openflow Connection for new switch:", dpid)
@@ -83,17 +83,13 @@ func NewSwitch(stream *util.MessageStream, dpid net.HardwareAddr, app AppInterfa
 
 		// Save it
 		switchDb.Set(dpid.String(), s)
-
-		// Main receive loop for the switch
-		go s.receive()
-
 	} else {
 		log.Infoln("Openflow re-connection for switch:", dpid)
 		s.stream = stream
 		s.dpid = dpid
 	}
 
-	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.ctx, s.cancel = context.WithCancel(pctx)
 	// send Switch connected callback
 	s.tlvMgr = newTLVMapMgr()
 


### PR DESCRIPTION
1. 流量可视化 collector 需要处理 bridge 删除
2. 手动 delete controller 之后会导致写入 closed socket
3. 原先的 libopenflow 实现中，写入导致的 outbound 会触发重连，目前为了防止丢消息会直接 fatal
4. 将 ofctrl conn 部分的 exit 管理 ctx，作为 pctx 传入 ofSwitch，实现 switch delete 资源清理
